### PR TITLE
Replaced Logger with *Logger in Log call

### DIFF
--- a/log.go
+++ b/log.go
@@ -7,7 +7,7 @@ type levelLogger struct {
 }
 
 func (me levelLogger) logf(level log.Level, format string, args ...interface{}) {
-	log.Fmsg(format, args...).AddValue(level).Skip(2).Log(me.Logger)
+	log.Fmsg(format, args...).AddValue(level).Skip(2).Log(&me.Logger)
 }
 
 func (me levelLogger) Infof(format string, args ...interface{}) {


### PR DESCRIPTION
../upnp/log.go:10:58: cannot use me.Logger (type "github.com/anacrolix/log".Logger) as type *"github.com/anacrolix/log".Logger in argument to "github.com/anacrolix/log".Fmsg(format, args...).AddValue(level).Skip(2).Log