### PR TITLE
Add DeletePortMapping method

### DIFF
--- a/interface.go
+++ b/interface.go
@@ -22,5 +22,6 @@ type Device interface {
 	ID() string
 	GetLocalIPAddress() net.IP
 	AddPortMapping(protocol Protocol, internalPort, externalPort int, description string, duration time.Duration) (int, error)
+	DeletePortMapping(protocol Protocol, externalPort int) error
 	GetExternalIPAddress() (net.IP, error)
 }


### PR DESCRIPTION
## Backgroud

I found that [torrent](https://github.com/anacrolix/torrent) just added port mapping but didn't clear the port mapping when the torrent was closed, which would cause the router to map more and more ports.

If this PR is merged, I'll submit a new PR on [torrent](https://github.com/anacrolix/torrent) to fix it.